### PR TITLE
feat:update

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -45,7 +45,6 @@ const Login = () => {
       return;
     }
 
-    // Step 2: validate password and sign in
     const passwordErr = validatePassword(password);
     setPasswordError(passwordErr);
     if (!passwordErr) {

--- a/app/(auth)/sign-up/page.tsx
+++ b/app/(auth)/sign-up/page.tsx
@@ -10,6 +10,7 @@ import { Eye, EyeClosed } from "lucide-react";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
 import { useMutation } from "@tanstack/react-query";
+import { signIn } from "next-auth/react";
 
 const SignUp = () => {
   const router = useRouter();
@@ -343,7 +344,10 @@ const SignUp = () => {
                         <span className="flex-1 border-[0.5px] border-[#F3F4F6]"></span>
                       </div>
                       <div className="grid grid-cols-3 lg:gap-3.5 gap-2">
-                        <div className="flex items-center justify-center py-2.5 px-4 rounded-[22px] lg:h-11 h-8 border border-[#F2F2F2] cursor-pointer">
+                        <div
+                          className="flex items-center justify-center py-2.5 px-4 rounded-[22px] lg:h-11 h-8 border border-[#F2F2F2] cursor-pointer"
+                          onClick={() => signIn("google")}
+                        >
                           <Image
                             src="/images/google.svg"
                             alt="google"

--- a/app/(root)/my-courses/page.tsx
+++ b/app/(root)/my-courses/page.tsx
@@ -32,7 +32,7 @@ const MyCourses = () => {
               ({ code, id, title, year, yearColor, bgColor, pillBg }) => (
                 <div
                   key={id}
-                  className="relative py-[22px] px-[18px] rounded-[14px] h-[85px] shadow-sm bg-white overflow-hidden cursor-pointer"
+                  className="relative py-[22px] px-[18px] rounded-[14px] minh-[85px] shadow-sm bg-white overflow-hidden cursor-pointer"
                   onClick={() => router.push(`/my-courses/${id}`)}
                 >
                   <div className="flex flex-col gap-1">

--- a/app/(root)/new-course/page.tsx
+++ b/app/(root)/new-course/page.tsx
@@ -32,6 +32,7 @@ import { useRouter } from "next/navigation";
 import { useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useSession } from "next-auth/react";
+import { useAccount } from "@/providers/AccountProvider";
 
 const formSchema = z.object({
   title: z.string().min(3, {
@@ -47,6 +48,8 @@ const formSchema = z.object({
 const NewCourse = () => {
   const router = useRouter();
   const { data: session } = useSession();
+  const { user } = useAccount();
+  console.log(user, "besky");
 
   // 1. Define your form.
   const form = useForm<z.infer<typeof formSchema>>({
@@ -61,6 +64,10 @@ const NewCourse = () => {
 
   const { mutate: createCourse, isPending } = useMutation({
     mutationFn: async (payload: z.infer<typeof formSchema>) => {
+      const fullPayload = {
+        ...payload,
+        organisation_id: user?.organisation?.org_id,
+      };
       const response = await fetch(
         `${process.env.NEXT_PUBLIC_API_URL}/main/course/update/`,
         {
@@ -69,7 +76,7 @@ const NewCourse = () => {
             "Content-Type": "application/json",
             Authorization: `Bearer ${session?.accessToken}`,
           },
-          body: JSON.stringify(payload),
+          body: JSON.stringify(fullPayload),
         }
       );
       if (!response.ok) {

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -91,8 +91,11 @@ const handler = NextAuth({
         );
         if (response.ok) {
           const data = await response.json();
-          token.accessToken = data.access;
-          token.user = data.user;
+          token.accessToken = data.data.access;
+          token.user = data.data.user;
+        } else {
+          token.accessToken = undefined;
+          token.user = undefined;
         }
       }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { Toaster } from "@/components/ui/sonner";
 import { Provider } from "@/providers/provider";
 import { SessionProvider } from "@/providers/SessionProvider";
+import { AccountProvider } from "@/providers/AccountProvider";
 
 export const metadata: Metadata = {
   title: "Passmark",
@@ -19,7 +20,9 @@ export default function RootLayout({
     <html lang="en" className={`${inter.variable} ${geist.variable}`}>
       <body>
         <SessionProvider>
-          <Provider>{children}</Provider>
+          <Provider>
+            <AccountProvider>{children}</AccountProvider>
+          </Provider>
         </SessionProvider>
         <Toaster richColors />
       </body>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -71,14 +71,20 @@ export const Header = () => {
             height={40}
           />
           <DropdownMenu>
-            <DropdownMenuTrigger className="flex justify-center items-center gap-1.5 h-9 pl-1 pt-[3px] pr-2 border border-[#EBEBEB] rounded-[22px]">
-              <div className="flex justify-center items-center">
-                <Image
-                  src="/images/profile.svg"
-                  alt="profile"
-                  width={32}
-                  height={32}
-                />
+            <DropdownMenuTrigger className="flex justify-center items-center gap-1.5 h-10 pl-1 pr-2 border border-[#EBEBEB] rounded-[22px]">
+              <div className="flex justify-center items-center gap-2">
+                <div className="relative flex justify-center items-center w-8 h-8 rounded-full">
+                  <Image
+                    src={
+                      session?.user?.image
+                        ? session?.user?.image
+                        : "/images/profile.svg"
+                    }
+                    alt="profile"
+                    fill
+                    className="absolute rounded-full object-contain"
+                  />
+                </div>
                 <p className="text-sm font-medium tracking-[-0.6%]">
                   {session?.user?.name || "User"}
                 </p>

--- a/components/user-header.tsx
+++ b/components/user-header.tsx
@@ -1,16 +1,18 @@
 import { Plus } from "lucide-react";
+import { useSession } from "next-auth/react";
 import Link from "next/link";
 
 export default function UserHeader() {
+  const { data: session } = useSession();
   return (
     <div className="flex lg:flex-row flex-col justify-between lg:items-center py-5 gap-4">
       <div className="flex items-center gap-[14px]">
-        <div className="flex justify-center items-center rounded-full lg:size-12 size-8 bg-[#C0D5FF] lg:text-[22px] text-base text-[#122368] font-bold">
-          G
+        <div className="flex justify-center items-center rounded-full lg:size-12 size-8 bg-[#C0D5FF] lg:text-[22px] text-base text-[#122368] font-bold uppercase">
+          {session?.user?.name?.split(" ")[0]?.charAt(0)}
         </div>
         <div className="flex flex-col lg:gap-1">
           <h5 className="lg:text-lg text-base text-[#171717] font-semibold">
-            George Chris
+            {session?.user?.name || "User"}
           </h5>
           <p className="lg:text-sm text-xs text-[#878787] font-medium">
             What are you marking today?

--- a/hooks/useFetchAccountDetails.tsx
+++ b/hooks/useFetchAccountDetails.tsx
@@ -1,0 +1,50 @@
+import { useQuery } from "@tanstack/react-query";
+import { useSession } from "next-auth/react";
+
+type Organisation = {
+  org_id: string;
+  name: string;
+  org_type: string;
+  created_at: string;
+};
+
+type User = {
+  email_verified: boolean;
+  email: string;
+  firstname: string;
+  lastname: string;
+  phone: string | null;
+  organisation: Organisation | null;
+};
+
+const getAccountDetails = async (token: string): Promise<User> => {
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/account/get-account/`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch account details");
+  }
+
+  const result = await response.json();
+  return result.data;
+};
+
+export const useFetchAccountDetails = () => {
+  const { data: session } = useSession();
+  const token = session?.accessToken;
+
+  return useQuery({
+    queryKey: ["accountDetails"],
+    queryFn: () => {
+      if (!token) throw new Error("No access token");
+      return getAccountDetails(token);
+    },
+    enabled: !!token,
+  });
+};

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,15 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "lh3.googleusercontent.com",
+        port: "",
+        pathname: "/**",
+      },
+    ],
+  },
+};
 
 export default nextConfig;

--- a/providers/AccountProvider.tsx
+++ b/providers/AccountProvider.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { createContext, useContext, ReactNode } from "react";
+import { useFetchAccountDetails } from "@/hooks/useFetchAccountDetails";
+
+type Organisation = {
+  org_id: string;
+  name: string;
+  org_type: string;
+  created_at: string;
+};
+
+type User = {
+  email_verified: boolean;
+  email: string;
+  firstname: string;
+  lastname: string;
+  phone: string | null;
+  organisation: Organisation | null;
+};
+
+type AccountContextType = {
+  user: User | undefined;
+  isLoading: boolean;
+  isError: boolean;
+};
+
+const AccountContext = createContext<AccountContextType | undefined>(undefined);
+
+export const AccountProvider = ({ children }: { children: ReactNode }) => {
+  const { data: user, isLoading, isError } = useFetchAccountDetails();
+
+  return (
+    <AccountContext.Provider value={{ user, isLoading, isError }}>
+      {children}
+    </AccountContext.Provider>
+  );
+};
+
+export const useAccount = () => {
+  const context = useContext(AccountContext);
+  if (context === undefined) {
+    throw new Error("useAccount must be used within an AccountProvider");
+  }
+  return context;
+};


### PR DESCRIPTION
feat: integrate Google OAuth, session-based API auth, and organization-aware course creation

- Implement Google sign-in and sign-up using NextAuth, including backend token exchange via /account/social-auth/
- Ensure access token and user data are stored in NextAuth session for both credentials and Google logins
- Refactor useFetchAccountDetails hook to use session token and match backend user data structure
- Add AccountProvider for global user data access throughout the app
- Update new-course page to include organisation_id from user context in course creation payload
- Allow images from Google user content domain in next.config.mjs for profile images
- Improve error handling and type safety in API hooks