### PR TITLE
fix: resolve TypeScript type inference issue in new-student page

### DIFF
--- a/app/(root)/new-course/[courseId]/new-student/page.tsx
+++ b/app/(root)/new-course/[courseId]/new-student/page.tsx
@@ -51,7 +51,7 @@ const NewStudent = () => {
   useEffect(() => {
     if (studentList) {
       // Transform the fetched students into our local format
-      const transformedStudents = studentList.map((student) => ({
+      const transformedStudents: Student[] = studentList.map((student) => ({
         id: student.student_number,
         name: student.full_name,
         student_id: student.student_id,


### PR DESCRIPTION
fix: resolve TypeScript type inference issue in new-student page

- Explicitly type transformedStudents array as Student[] to allow optional student_id
- Remove unnecessary type assertions