### PR TITLE
feat: add approve modal and query invalidation to marked scripts table

### DIFF
--- a/app/(root)/components/columns.tsx
+++ b/app/(root)/components/columns.tsx
@@ -1,9 +1,31 @@
 "use client";
 
-import { ColumnDef } from "@tanstack/react-table";
+import { ColumnDef, RowData } from "@tanstack/react-table";
 import Image from "next/image";
 import { MarkedScript } from "@/lib/data";
 import { Checkbox } from "@/components/ui/checkbox";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
+import { useAcceptScript } from "@/hooks/useAcceptScript";
+import { useQueryClient } from "@tanstack/react-query";
+
+// Add TableMeta augmentation for onApprove
+
+declare module "@tanstack/react-table" {
+  interface TableMeta<TData extends RowData> {
+    onApprove?: (script_id: string) => void;
+  }
+} 
 
 // Helper to format date
 function formatDate(dateString: string | null | undefined) {
@@ -173,7 +195,7 @@ export const columns: ColumnDef<MarkedScript>[] = [
       <div className="flex items-center gap-1 border border-[#EBEBEB] bg-white w-fit h-6 p-1 pr-2 rounded-md whitespace-nowrap">
         <Image
           src={`/images/${
-            row.original?.status?.toLocaleLowerCase() === "approved"
+            row.original?.status?.toLocaleLowerCase() === "completed"
               ? "check"
               : row.original?.status?.toLocaleLowerCase() === "pending"
               ? "alert"
@@ -209,22 +231,44 @@ export const columns: ColumnDef<MarkedScript>[] = [
         </div>
       );
     },
-    cell: ({ row }) => {
+    cell: ({ row, table }) => {
+      // Expect an onApprove handler to be passed via table.options.meta
+      const onApprove = table.options.meta?.onApprove;
       const status = row.original?.status?.toLowerCase();
       const actions =
         status === "pending" ? ["View Script", "Approve"] : ["View Script"];
       return (
         <div className="flex gap-2">
-          {actions.map((action: string, index: number) => (
-            <div
-              key={index}
-              className="flex justify-center items-center border border-[#EBEBEB] bg-white w-fit h-8 shadow-sm px-3 rounded-lg"
-            >
-              <p className="text-[#5C5C5C] font-medium text-sm tracking-[0.6px] leading-5 whitespace-nowrap">
-                {action}
-              </p>
-            </div>
-          ))}
+          {actions.map((action: string, index: number) => {
+            if (action === "Approve") {
+              return (
+                <div
+                  key={index}
+                  className="flex justify-center items-center border border-[#EBEBEB] bg-white w-fit h-8 shadow-sm px-3 rounded-lg cursor-pointer"
+                  onClick={() => onApprove && onApprove(row.original.script_id)}
+                >
+                  <p className="text-[#5C5C5C] font-medium text-sm tracking-[0.6px] leading-5 whitespace-nowrap">
+                    {action}
+                  </p>
+                </div>
+              );
+            }
+            return (
+              <div
+                key={index}
+                className="flex justify-center items-center border border-[#EBEBEB] bg-white w-fit h-8 shadow-sm px-3 rounded-lg cursor-pointer"
+                onClick={() => {
+                  if (action === "View Script") {
+                    window.location.href = `/marked-scripts/${row.original.student_id}`;
+                  }
+                }}
+              >
+                <p className="text-[#5C5C5C] font-medium text-sm tracking-[0.6px] leading-5 whitespace-nowrap">
+                  {action}
+                </p>
+              </div>
+            );
+          })}
         </div>
       );
     },

--- a/app/(root)/marked-scripts/components/columns.tsx
+++ b/app/(root)/marked-scripts/components/columns.tsx
@@ -4,6 +4,7 @@ import { ColumnDef } from "@tanstack/react-table";
 import Image from "next/image";
 import { MarkedScript } from "@/lib/data";
 import { Checkbox } from "@/components/ui/checkbox";
+import { useRouter } from "next/navigation";
 
 // Helper to format date
 function formatDate(dateString: string | null | undefined) {
@@ -173,7 +174,7 @@ export const columns: ColumnDef<MarkedScript>[] = [
       <div className="flex items-center gap-1 border border-[#EBEBEB] bg-white w-fit h-6 p-1 pr-2 rounded-md whitespace-nowrap">
         <Image
           src={`/images/${
-            row.original?.status?.toLocaleLowerCase() === "approved"
+            row.original?.status?.toLocaleLowerCase() === "completed"
               ? "check"
               : row.original?.status?.toLocaleLowerCase() === "pending"
               ? "alert"
@@ -209,22 +210,46 @@ export const columns: ColumnDef<MarkedScript>[] = [
         </div>
       );
     },
-    cell: ({ row }) => {
+    cell: function ActionsCell({ row, table }) {
+      const router = useRouter();
+      const onApprove = table.options.meta?.onApprove;
       const status = row.original?.status?.toLowerCase();
       const actions =
         status === "pending" ? ["View Script", "Approve"] : ["View Script"];
       return (
         <div className="flex gap-2">
-          {actions.map((action: string, index: number) => (
-            <div
-              key={index}
-              className="flex justify-center items-center border border-[#EBEBEB] bg-white w-fit h-8 shadow-sm px-3 rounded-lg"
-            >
-              <p className="text-[#5C5C5C] font-medium text-sm tracking-[0.6px] leading-5 whitespace-nowrap">
-                {action}
-              </p>
-            </div>
-          ))}
+          {actions.map((action: string, index: number) => {
+            if (action === "Approve") {
+              return (
+                <div
+                  key={index}
+                  className="flex justify-center items-center border border-[#EBEBEB] bg-white w-fit h-8 shadow-sm px-3 rounded-lg cursor-pointer"
+                  onClick={() => onApprove && onApprove(row.original.script_id)}
+                >
+                  <p className="text-[#5C5C5C] font-medium text-sm tracking-[0.6px] leading-5 whitespace-nowrap">
+                    {action}
+                  </p>
+                </div>
+              );
+            }
+            return (
+              <div
+                key={index}
+                className="flex justify-center items-center border border-[#EBEBEB] bg-white w-fit h-8 shadow-sm px-3 rounded-lg cursor-pointer"
+                onClick={() => {
+                  if (action === "View Script") {
+                    router.push(
+                      `/marked-scripts/${row.original.student.student_id}`
+                    );
+                  }
+                }}
+              >
+                <p className="text-[#5C5C5C] font-medium text-sm tracking-[0.6px] leading-5 whitespace-nowrap">
+                  {action}
+                </p>
+              </div>
+            );
+          })}
         </div>
       );
     },

--- a/app/(root)/marked-scripts/page.tsx
+++ b/app/(root)/marked-scripts/page.tsx
@@ -8,6 +8,11 @@ import { columns } from "./components/columns";
 import { useFetchScripts } from "@/hooks/useFetchScripts";
 import { useAccount } from "@/providers/AccountProvider";
 import ScriptsTableSkeleton from "@/components/skeletons/ScriptsTableSkeleton";
+import { useState } from "react";
+import { useAcceptScript } from "@/hooks/useAcceptScript";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import dynamic from "next/dynamic";
 
 const MarkedScripts = () => {
   const router = useRouter();
@@ -20,22 +25,121 @@ const MarkedScripts = () => {
   const pendingCount = data.filter(
     (s) => s.status.toLowerCase() === "pending"
   ).length;
+
+  // Approve modal state and logic
+  const [approveDialogOpen, setApproveDialogOpen] = useState(false);
+  const [selectedScriptId, setSelectedScriptId] = useState<string | null>(null);
+  const { mutate: acceptScript, isPending: isAccepting } = useAcceptScript();
+  const queryClient = useQueryClient();
+
+  const handleApprove = (script_id: string) => {
+    setSelectedScriptId(script_id);
+    setApproveDialogOpen(true);
+  };
+
+  const handleApproveConfirm = () => {
+    if (!selectedScriptId) return;
+    acceptScript(
+      { script_id: selectedScriptId },
+      {
+        onSuccess: () => {
+          toast.success("Script approved successfully");
+          setApproveDialogOpen(false);
+          setSelectedScriptId(null);
+          queryClient.invalidateQueries({
+            queryKey: ["scripts", organisationId],
+          });
+        },
+        onError: (error: any) => {
+          toast.error(error.message || "Failed to approve script");
+        },
+      }
+    );
+  };
+
+  // Dynamically import Dialog to avoid SSR issues
+  const Dialog = dynamic(
+    () => import("@/components/ui/dialog").then((mod) => mod.Dialog),
+    { ssr: false }
+  );
+  const DialogContent = dynamic(
+    () => import("@/components/ui/dialog").then((mod) => mod.DialogContent),
+    { ssr: false }
+  );
+  const DialogTitle = dynamic(
+    () => import("@/components/ui/dialog").then((mod) => mod.DialogTitle),
+    { ssr: false }
+  );
+  const DialogDescription = dynamic(
+    () => import("@/components/ui/dialog").then((mod) => mod.DialogDescription),
+    { ssr: false }
+  );
+  const DialogClose = dynamic(
+    () => import("@/components/ui/dialog").then((mod) => mod.DialogClose),
+    { ssr: false }
+  );
+  const Button = dynamic(
+    () => import("@/components/ui/button").then((mod) => mod.Button),
+    { ssr: false }
+  );
+  const Image = dynamic(() => import("next/image"), { ssr: false });
+
   return (
     <main className="flex flex-col gap-5 lg:px-[108px] md:px-[20] p-5 pt-10">
       <ScriptCards approvedCount={approvedCount} pendingCount={pendingCount} />
       {isLoading ? (
         <ScriptsTableSkeleton />
       ) : (
-        <DataTable
-          columns={columns}
-          data={data}
-          searchKey="file_name"
-          tableName="Recently marked scripts"
-          getId={(row) => row.student.student_id}
-          onRowClick={(row: MarkedScript) =>
-            router.push(`/marked-scripts/${row.student.student_id}`)
-          }
-        />
+        <>
+          <DataTable
+            columns={columns}
+            data={data}
+            searchKey="file_name"
+            tableName="Recently marked scripts"
+            getId={(row) => row.student.student_id}
+            meta={{ onApprove: handleApprove }}
+          />
+          <Dialog open={approveDialogOpen} onOpenChange={setApproveDialogOpen}>
+            <DialogContent
+              className="max-w-[357px] px-5 py-4 text-center"
+              style={{ borderRadius: "20px" }}
+            >
+              <div className="flex flex-col items-center">
+                <div className="bg-[#FEEDE1] rounded-[10px] p-2 w-10 h-10 flex items-center justify-center mb-4">
+                  <Image
+                    src="/images/alert.svg"
+                    alt="alert"
+                    width={40}
+                    height={40}
+                  />
+                </div>
+                <DialogTitle className="text-base text-[#171717] font-semibold mb-2">
+                  Are you sure?
+                </DialogTitle>
+                <DialogDescription className="text-sm mb-6 text-[#8C8C8C]">
+                  Kindly confirm that you want to approve this script.
+                </DialogDescription>
+                <div className="flex gap-3 w-full justify-center">
+                  <DialogClose asChild>
+                    <Button
+                      variant="outline"
+                      className="w-1/2 border-none  lg:h-10 h-8 bg-[#F5F7FF] border border-[#F0F3FF] text-[#335CFF] lg:text-sm text-xs tracking-[1.5%] rounded-[10px] lg:font-semibold font-medium hover:bg-[#F0F3FF] hover:text-primary"
+                    >
+                      No, Cancel
+                    </Button>
+                  </DialogClose>
+                  <Button
+                    className="w-1/2 bg-[#335CFF] hover:bg-[#2346A0] flex items-center gap-1 whitespace-nowrap bg-gradient-to-t from-[#0089FF] to-[#0068FF] rounded-[10px] p-2.5 text-white lg:h-10 h-8 cursor-pointer hover:opacity-95 transition-all duration-300 lg:text-sm text-xs lg:font-semibold font-medium"
+                    disabled={isAccepting}
+                    onClick={handleApproveConfirm}
+                  >
+                    {isAccepting ? "Approving..." : "Yes, Approve"}
+                  </Button>
+                </div>
+              </div>
+            </DialogContent>
+          </Dialog>
+        </>
       )}
     </main>
   );

--- a/app/(root)/page.tsx
+++ b/app/(root)/page.tsx
@@ -9,11 +9,79 @@ import { useRouter } from "next/navigation";
 import EmptyState from "@/components/empty-state";
 import ScriptsTableSkeleton from "@/components/skeletons/ScriptsTableSkeleton";
 import { useFetchOrganisationScriptList } from "@/hooks/useFetchOrganisationScriptList";
+import { useState } from "react";
+import { useAcceptScript } from "@/hooks/useAcceptScript";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import dynamic from "next/dynamic";
 
 export default function Home() {
   const router = useRouter();
-  const { data: scripts, isLoading, isError } = useFetchOrganisationScriptList();
+  const {
+    data: scripts,
+    isLoading,
+    isError,
+  } = useFetchOrganisationScriptList();
 
+  // Approve modal state and logic
+  const [approveDialogOpen, setApproveDialogOpen] = useState(false);
+  const [selectedScriptId, setSelectedScriptId] = useState<string | null>(null);
+  const { mutate: acceptScript, isPending: isAccepting } = useAcceptScript();
+  const queryClient = useQueryClient();
+
+  const handleApprove = (script_id: string) => {
+    setSelectedScriptId(script_id);
+    setApproveDialogOpen(true);
+  };
+
+  const handleApproveConfirm = () => {
+    if (!selectedScriptId) return;
+    acceptScript(
+      { script_id: selectedScriptId },
+      {
+        onSuccess: () => {
+          toast.success("Script approved successfully");
+          setApproveDialogOpen(false);
+          setSelectedScriptId(null);
+          queryClient.invalidateQueries({
+            queryKey: ["organisationScriptList"],
+          });
+        },
+        onError: (error: any) => {
+          toast.error(error.message || "Failed to approve script");
+        },
+      }
+    );
+  };
+
+  // Dynamically import Dialog to avoid SSR issues
+  const Dialog = dynamic(
+    () => import("@/components/ui/dialog").then((mod) => mod.Dialog),
+    { ssr: false }
+  );
+  const DialogContent = dynamic(
+    () => import("@/components/ui/dialog").then((mod) => mod.DialogContent),
+    { ssr: false }
+  );
+  const DialogTitle = dynamic(
+    () => import("@/components/ui/dialog").then((mod) => mod.DialogTitle),
+    { ssr: false }
+  );
+  const DialogDescription = dynamic(
+    () => import("@/components/ui/dialog").then((mod) => mod.DialogDescription),
+    { ssr: false }
+  );
+  const DialogClose = dynamic(
+    () => import("@/components/ui/dialog").then((mod) => mod.DialogClose),
+    { ssr: false }
+  );
+  const Button = dynamic(
+    () => import("@/components/ui/button").then((mod) => mod.Button),
+    { ssr: false }
+  );
+  const Image = dynamic(() => import("next/image"), { ssr: false });
+
+  // Pass approve handler to DataTable via meta prop
   return (
     <main className="flex flex-col gap-5 lg:px-[108px] md:px-[20] px-5">
       <UserHeader />
@@ -32,16 +100,56 @@ export default function Home() {
           showIcon={false}
         />
       ) : (
-        <DataTable
-          columns={columns}
-          data={scripts}
-          searchKey="scriptUploaded"
-          tableName="Recently marked scripts"
-          getId={(row) => row.student_id}
-          onRowClick={(row: MarkedScript) =>
-            router.push(`/marked-scripts/${row.student_id}`)
-          }
-        />
+        <>
+          <DataTable
+            columns={columns}
+            data={scripts}
+            searchKey="scriptUploaded"
+            tableName="Recently marked scripts"
+            getId={(row) => row.student_id}
+            meta={{ onApprove: handleApprove }}
+          />
+          <Dialog open={approveDialogOpen} onOpenChange={setApproveDialogOpen}>
+            <DialogContent
+              className="max-w-[357px] px-5 py-4 text-center"
+              style={{ borderRadius: "20px" }}
+            >
+              <div className="flex flex-col items-center">
+                <div className="bg-[#FEEDE1] rounded-[10px] p-2 w-10 h-10 flex items-center justify-center mb-4">
+                  <Image
+                    src="/images/alert.svg"
+                    alt="alert"
+                    width={40}
+                    height={40}
+                  />
+                </div>
+                <DialogTitle className="text-base text-[#171717] font-semibold mb-2">
+                  Are you sure?
+                </DialogTitle>
+                <DialogDescription className="text-sm mb-6 text-[#8C8C8C]">
+                  Kindly confirm that you want to approve this script.
+                </DialogDescription>
+                <div className="flex gap-3 w-full justify-center">
+                  <DialogClose asChild>
+                    <Button
+                      variant="outline"
+                      className="w-1/2 border-none  lg:h-10 h-8 bg-[#F5F7FF] border border-[#F0F3FF] text-[#335CFF] lg:text-sm text-xs tracking-[1.5%] rounded-[10px] lg:font-semibold font-medium hover:bg-[#F0F3FF] hover:text-primary"
+                    >
+                      No, Cancel
+                    </Button>
+                  </DialogClose>
+                  <Button
+                    className="w-1/2 bg-[#335CFF] hover:bg-[#2346A0] flex items-center gap-1 whitespace-nowrap bg-gradient-to-t from-[#0089FF] to-[#0068FF] rounded-[10px] p-2.5 text-white lg:h-10 h-8 cursor-pointer hover:opacity-95 transition-all duration-300 lg:text-sm text-xs lg:font-semibold font-medium"
+                    disabled={isAccepting}
+                    onClick={handleApproveConfirm}
+                  >
+                    {isAccepting ? "Approving..." : "Yes, Approve"}
+                  </Button>
+                </div>
+              </div>
+            </DialogContent>
+          </Dialog>
+        </>
       )}
     </main>
   );

--- a/components/data-table.tsx
+++ b/components/data-table.tsx
@@ -60,6 +60,7 @@ interface DataTableProps<TData, TValue> {
   tableName: string;
   getId: (row: TData) => string | number;
   onRowClick?: (row: TData) => void;
+  meta?: any; // Allow passing meta for table.options.meta
 }
 
 export function DataTable<TData, TValue>({
@@ -69,6 +70,7 @@ export function DataTable<TData, TValue>({
   tableName,
   getId,
   onRowClick,
+  meta,
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
@@ -133,6 +135,7 @@ export function DataTable<TData, TValue>({
       sorting,
       columnFilters,
     },
+    meta, // Pass meta to table instance
   });
 
   const pageSize = table.getState().pagination.pageSize;


### PR DESCRIPTION
- Show approve confirmation modal when clicking "Approve" in the table
- Use router.push for "View Script" navigation
- Invalidate scripts query after approval to refresh table data
- Remove row click navigation; only action buttons trigger navigation or modals