### PR TITLE
feat: add useExtractQuestions hook for question extraction

### DIFF
--- a/hooks/useExtractQuestions.tsx
+++ b/hooks/useExtractQuestions.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useMutation } from "@tanstack/react-query";
+import { useSession } from "next-auth/react";
+import { useAccount } from "@/providers/AccountProvider";
+
+export type ExtractQuestionsPayload = {
+  assessment_id: string;
+  doc_url: string;
+};
+
+export type ExtractQuestionsResponse = {
+  status: boolean;
+  message: string;
+};
+
+const extractQuestions = async (
+  token: string,
+  payload: ExtractQuestionsPayload
+): Promise<ExtractQuestionsResponse> => {
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/main/question/extract-questions/`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(payload),
+    }
+  );
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.message || "Failed to extract questions");
+  }
+
+  return response.json();
+};
+
+export const useExtractQuestions = () => {
+  const { data: session } = useSession();
+  const token = session?.accessToken;
+
+  return useMutation({
+    mutationFn: (payload: ExtractQuestionsPayload) => {
+      if (!token) throw new Error("No access token");
+      return extractQuestions(token, payload);
+    },
+  });
+};


### PR DESCRIPTION
- Add new hook to extract questions from assessment documents
- Endpoint: /main/question/extract-questions/
- Supports assessment_id and doc_url payload
- Includes proper TypeScript types and error handling
- Follows existing codebase patterns with React Query and authentication